### PR TITLE
Fixed umlaut encoding bug for qr-codes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -166,7 +166,7 @@ def create_qr_code(text, size, correction, fill_color):
         box_size=size,
         border=0,
     )
-    qr.add_data(text)
+    qr.add_data(text.encode("utf-8-sig"))
     qr.make(fit=True)
     qr_img = qr.make_image(
         fill_color='red' if (255, 0, 0) == fill_color else 'black',


### PR DESCRIPTION
when the generated qr-codes are decoded using qrtools, codes containing umlauts (e.g. ä,ö,ü) are decoded incorrectly.
using the utf-8-sig encoding enables the decoder to determine the source encoding and correctly decode the data