### PR TITLE
Feature: Printing red images & Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3-alpine
+
+COPY . /app
+WORKDIR /app
+
+RUN apk add fontconfig \
+    git \
+    ttf-dejavu \
+    ttf-liberation \
+    ttf-droid \
+    font-terminus \
+    font-inconsolata \
+    font-dejavu \
+    font-noto \
+    poppler-utils && \
+    fc-cache -f && \
+    pip3 install -r requirements.txt
+
+EXPOSE 8013
+ENTRYPOINT [ "python3", "run.py" ]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## brother\_ql\_web
+## brother_ql_web
 
 This is a web service to print labels on Brother QL label printers.
 
-You need Python 3 for this software to work.
+You need Python 3 or Docker for this software to work.
 
 ![Screenshot](./screenshots/Label-Designer_Desktop.png)
 
@@ -10,18 +10,19 @@ The web interface is [responsive](https://en.wikipedia.org/wiki/Responsive_web_d
 There's also a screenshot showing [how it looks on a smartphone](./screenshots/Label-Designer_Phone.png)
 
 ### Additional Features
-* Print text as QR Code
-    * Add text to QR Code
-    * Change size of QR Code
-* Upload files to print
-    * .pdf, .png and .jpg files
-    * automatically convertion to black/white image
-* Change print color for black/white/red labels
-* Print lables multiple times
-    * Cut every label
-    * Cut only after the last label
-* Migrated GUI to Bootstrap 4
-* Make preview for round labels.. round
+
+-   Print text as QR Code
+    -   Add text to QR Code
+    -   Change size of QR Code
+-   Upload files to print
+    -   .pdf, .png and .jpg files
+    -   automatically convertion to black/white image
+-   Change print color for black/white/red labels
+-   Print lables multiple times
+    -   Cut every label
+    -   Cut only after the last label
+-   Migrated GUI to Bootstrap 4
+-   Make preview for round labels.. round
 
 ### Installation
 
@@ -42,20 +43,25 @@ Build the venv and install the requirements:
     source /opt/brother_ql_web/.venv/bin/activate
     pip install -r requirements.txt
 
-### Configuration file
+#### Configuration file
 
 Create a directory called 'instance', a file called 'application.py' and adjust the values to match your needs.
 
+```bash
     mkdir /opt/brother_ql_web/instance
     touch /opt/brother_ql_web/instance/application.py
+```
 
 E.g.
-    """
-    User specific application settings
-    """
-    import logging
-    PRINTER_MODEL = 'QL-820NWB'
-    PRINTER_PRINTER = 'tcp://192.168.1.33:9100'
+
+```python
+"""
+User specific application settings
+"""
+import logging
+PRINTER_MODEL = 'QL-820NWB'
+PRINTER_PRINTER = 'tcp://192.168.1.33:9100'
+```
 
 ### Startup
 
@@ -70,6 +76,37 @@ Copy service file, reload system, enable and start the service
     systemctl enable brother_ql_web
     systemctl start brother_ql_web
 
+### Run via Docker
+
+To build the image:
+
+```bash
+git clone https://github.com/tbnobody/brother_ql_web.git
+cd brother_ql_web
+docker buildx build -t brother-ql-web .
+
+# alternatively, if buildx is not available
+docker build -t brother-ql-web .
+```
+
+You can then start your newly build image with `docker run`.
+You have to pass your printer model as `--model` argument. At the end of the arguments you have to add your device socket (linux kernel backend), USB identifier (pyusb backend) or network address (TCP).
+Please note you might have to pass your device to the container via the `--device` flag.
+
+Example command to start the application, connecting to a QL-800 on `/dev/usb/lp0`, setting label size to 62mm:
+
+```bash
+docker run -d \
+    --restart=always \
+    --name=brother-ql-web \
+    -p 8013:8013 \
+    --device=/dev/usb/lp0 \
+    brother-ql-web:latest \
+    --default-label-size 62 \
+    --model QL-800 \
+    file:///dev/usb/lp0
+```
+
 ### Usage
 
 Once it's running, access the web interface by opening the page with your browser.
@@ -78,9 +115,9 @@ You will then be forwarded by default to the interactive web gui located at `/la
 
 All in all, the web server offers:
 
-* a Web GUI allowing you to print your labels at `/labeldesigner`,
-* an API at `/api/print/text?text=Your_Text&font_size=100&font_family=Minion%20Pro%20(%20Semibold%20)`
-  to print a label containing 'Your Text' with the specified font properties.
+-   a Web GUI allowing you to print your labels at `/labeldesigner`,
+-   an API at `/api/print/text?text=Your_Text&font_size=100&font_family=Minion%20Pro%20(%20Semibold%20)`
+    to print a label containing 'Your Text' with the specified font properties.
 
 ### License
 
@@ -88,6 +125,6 @@ This software is published under the terms of the GPLv3, see the LICENSE file in
 
 Parts of this package are redistributed software products from 3rd parties. They are subject to different licenses:
 
-* [Bootstrap](https://github.com/twbs/bootstrap), MIT License
-* [Font Awesome](https://github.com/FortAwesome/Font-Awesome), CC BY 4.0 License
-* [jQuery](https://github.com/jquery/jquery), MIT License
+-   [Bootstrap](https://github.com/twbs/bootstrap), MIT License
+-   [Font Awesome](https://github.com/FortAwesome/Font-Awesome), CC BY 4.0 License
+-   [jQuery](https://github.com/jquery/jquery), MIT License

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -77,8 +77,6 @@ def main(app):
 
 def parse_args(app):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--font-folder', default=False,
-                        help='folder for additional .ttf/.otf fonts')
     parser.add_argument('--default-label-size', default=False,
                         help='Label size inserted in your printer. Defaults to 62.')
     parser.add_argument('--default-orientation', default=False, choices=('standard', 'rotated'),

--- a/app/labeldesigner/label.py
+++ b/app/labeldesigner/label.py
@@ -9,6 +9,8 @@ class LabelContent(Enum):
     TEXT_QRCODE = auto()
     IMAGE_BW = auto()
     IMAGE_GRAYSCALE = auto()
+    IMAGE_RED_BLACK = auto()
+    IMAGE_COLORED = auto()
 
 
 class LabelOrientation(Enum):
@@ -116,7 +118,7 @@ class SimpleLabel:
     def generate(self):
         if self._label_content in (LabelContent.QRCODE_ONLY, LabelContent.TEXT_QRCODE):
             img = self._generate_qr()
-        elif self._label_content in (LabelContent.IMAGE_BW, LabelContent.IMAGE_GRAYSCALE):
+        elif self._label_content in (LabelContent.IMAGE_BW, LabelContent.IMAGE_GRAYSCALE, LabelContent.IMAGE_RED_BLACK, LabelContent.IMAGE_COLORED):
             img = self._image
         else:
             img = None

--- a/app/labeldesigner/printer.py
+++ b/app/labeldesigner/printer.py
@@ -67,10 +67,10 @@ class PrinterQueue:
 
             img = queue_entry['label'].generate()
 
-            if queue_entry['label'].label_content == LabelContent.IMAGE_GRAYSCALE: 
-                dither = True
-            else:
+            if queue_entry['label'].label_content == LabelContent.IMAGE_BW: 
                 dither = False
+            else:
+                dither = True
 
             create_label(
                 qlr,

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -6,7 +6,7 @@ from brother_ql.devicedependent import label_type_specs, label_sizes, two_color_
 from brother_ql.devicedependent import ENDLESS_LABEL, DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL
 
 from . import bp
-from app.utils import convert_image_to_bw, convert_image_to_grayscale, pdffile_to_image, imgfile_to_image, image_to_png_bytes
+from app.utils import convert_image_to_bw, convert_image_to_grayscale, convert_image_to_red_and_black, pdffile_to_image, imgfile_to_image, image_to_png_bytes
 from app import FONTS
 
 from .label import SimpleLabel, LabelContent, LabelOrientation, LabelType
@@ -171,6 +171,10 @@ def create_label_from_request(request):
                 image = imgfile_to_image(image)
                 if context['image_mode'] == 'grayscale':
                     return convert_image_to_grayscale(image)
+                elif context['image_mode'] == 'red_and_black':
+                    return convert_image_to_red_and_black(image)
+                elif context['image_mode'] == 'colored':
+                    return image
                 else:
                     return convert_image_to_bw(image, context['image_bw_threshold'])
             elif ext.lower() in ('.pdf'):
@@ -192,6 +196,10 @@ def create_label_from_request(request):
         label_content = LabelContent.TEXT_QRCODE
     elif context['image_mode'] == 'grayscale':
         label_content = LabelContent.IMAGE_GRAYSCALE
+    elif context['image_mode'] == 'red_black':
+        label_content = LabelContent.IMAGE_RED_BLACK
+    elif context['image_mode'] == 'colored':
+        label_content = LabelContent.IMAGE_COLORED
     else:
         label_content = LabelContent.IMAGE_BW
 

--- a/app/labeldesigner/templates/labeldesigner.html
+++ b/app/labeldesigner/templates/labeldesigner.html
@@ -129,16 +129,26 @@
                     <div id="collapse5" class="collapse" aria-labelledby="heading5" data-parent="#accordion">
                         <div class="card-body">
                             <label for="imageMode" class="control-label input-group" style="margin-top: 10px; margin-bottom: 0">Image mode:</label>
-                            <div class="btn-group btn-group-toggle btn-block" data-toggle="buttons">
-                                <label class="btn btn-secondary {% if default_image_mode == 'black_and_white' %}active{% endif %}" id="image_mode_bw">
-                                    <input type="radio" name="imageMode" onchange="preview()" value="black_and_white" aria-label="Black & White" {% if default_image_mode == 'black_and_white' %}checked{% endif %}>
-                                    <span class="fas fa-ruler-horizontal" aria-hidden="true"> Black & White
-                                </label>
-                                <label class="btn btn-secondary {% if default_image_mode == 'grayscale' %}active{% endif %}" id="image_mode_grayscale">
-                                    <input type="radio" name="imageMode" onchange="preview()" value="grayscale" aria-label="Grayscale" {% if default_image_mode == 'grayscale' %}checked{% endif %}>
-                                    <span class="fas fa-ruler-vertical" aria-hidden="true"> Grayscale
-                                </label>
-                            </div>
+
+                            <label class="btn btn-secondary {% if default_image_mode == 'black_and_white' %}active{% endif %}" id="image_mode_bw">
+                                <input type="radio" name="imageMode" onchange="preview()" value="black_and_white" aria-label="Black & White" {% if default_image_mode == 'black_and_white' %}checked{% endif %}>
+                                <span class="fas fa-ruler-horizontal" aria-hidden="true"> Black & White
+                            </label>
+                            <label class="btn btn-secondary {% if default_image_mode == 'grayscale' %}active{% endif %}" id="image_mode_grayscale">
+                                <input type="radio" name="imageMode" onchange="preview()" value="grayscale" aria-label="Grayscale" {% if default_image_mode == 'grayscale' %}checked{% endif %}>
+                                <span class="fas fa-ruler-vertical" aria-hidden="true"> Grayscale
+                            </label>
+                            {% if red_support %}
+                            <label class="btn btn-secondary {% if default_image_mode == 'colored' %}active{% endif %}" id="image_mode_colored">
+                                <input type="radio" name="imageMode" onchange="preview()" value="colored" aria-label="Colored" {% if default_image_mode == 'colored' %}checked{% endif %}>
+                                <span class="fas fa-ruler-horizontal" aria-hidden="true"> Colored
+                            </label>
+                            <label class="btn btn-secondary {% if default_image_mode == 'red_and_black' %}active{% endif %}" id="image_mode_red_and_black">
+                                <input type="radio" name="imageMode" onchange="preview()" value="red_and_black" aria-label="Red & Black" {% if default_image_mode == 'red_and_black' %}checked{% endif %}>
+                                <span class="fas fa-ruler-vertical" aria-hidden="true"> Red & Black
+                            </label>
+                            {% endif %}
+                               
 
                             <label for="imageBwThreshold" style="margin-top: 10px; margin-bottom: 0">Black & White threshold:</label>
                             <input id="imageBwThreshold" class="form-control" type="number" min="1" max="255" value="{{default_bw_threshold}}" onChange="preview()">

--- a/app/labeldesigner/templates/main.js
+++ b/app/labeldesigner/templates/main.js
@@ -78,9 +78,13 @@ function preview() {
     if ($('#labelSize option:selected').val().includes('red')) {
         $('#print_color_black').removeClass('disabled');
         $('#print_color_red').removeClass('disabled');
+        $('#image_mode_red_and_black').removeClass('disabled');
+        $('#image_mode_colored').removeClass('disabled');
     } else {
         $('#print_color_black').addClass('disabled').prop('active', true);
         $('#print_color_red').addClass('disabled');
+        $('#image_mode_red_and_black').addClass('disabled');
+        $('#image_mode_colored').addClass('disabled');
     }
     {% endif %}
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from PIL import Image
+from PIL.ImageOps import colorize
 from io import BytesIO
 from pdf2image import convert_from_bytes
 
@@ -12,6 +13,9 @@ def convert_image_to_bw(image, threshold):
 def convert_image_to_grayscale(image):
     fn = lambda x : 255 if x > threshold else 0
     return image.convert('L') # convert to greyscale
+
+def convert_image_to_red_and_black(image):
+    return colorize(image.convert('L'), black='black', white='white', mid='red')
 
 
 def imgfile_to_image(file):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-brother_ql
+brother_ql-inventree
 Flask
 flask_bootstrap4
 qrcode


### PR DESCRIPTION
Hi, hope it's okay to make a packed PR like this, I can of course also split it up into one for each changeset.

### Swapping upstream `brother_ql` dependency

Since this seems to be the most maintained fork of the original repo, I was curious about future-proofing it a bit more. I would suggest swapping the `brother_ql` dependency for the more recent and better packaged [brother_ql-inventree](https://github.com/matmair/brother_ql-inventree). This is totally up for debate, as the original repo vom @pklaus was working for me, except for some minor dependency issue with pillow.

### Docker support, arg parsing

I added a Dockerfile which keeps things fairly simple. I have noticed the PR #2, although this is now fairly outdated since you changed to Flasks config instead of manual parsing. Some command line args are needed to pass into the docker container, so I reintroduced some of those. The image uses the official python alpine as base and also downloads some fonts.

### Red/"redscale" images
Since printing black/white/red images via `brother_ql` CLI works very well, I was motivated to add this to the frontend. The naming and UX is up for debate, but I've introduced two new color modes, `colored` and `black_and_red`. Colored mode is not processing the image at all, best used with images that are already mostly black, white and red. Think warning signs and stuff. Black and red mode is turning the image to greyscale first, and then mapping midtones to red, so you can pass RGB images and have them use the 2 available colors as good as it allows.

I've attached screenshots of both modes to make it a bit more clear.

Colored mode (no processing):

![colored](https://github.com/tbnobody/brother_ql_web/assets/30576493/fa15fdd0-ad5a-460c-a351-2eebda5d3a55)

Red & black processing:

![red_black](https://github.com/tbnobody/brother_ql_web/assets/30576493/bd79e5e0-ec55-4755-8444-fb5a53c5d4a4)
